### PR TITLE
Normalize Sala and Qala to One Word Each

### DIFF
--- a/maha/constants/arabic/compound.py
+++ b/maha/constants/arabic/compound.py
@@ -157,8 +157,8 @@ ARABIC_LIGATURES: List[str] = [
 """ Arabic word ligatures. """
 
 ARABIC_LIGATURES_NORMALIZED: List[str] = [
-    LIGATURE_SALLA_KORANIC,  # TODO: Find the normalized version for this
-    LIGATURE_QALA,  # TODO: Find the normalized version for this
+    "صلى",
+    "قلى",
     "الله",
     "اكبر",
     "محمد",


### PR DESCRIPTION
**What does this pull request change**?

- It normalizes 2 ligatures. The normalization however can be done in two different ways;
    - The way they are written (صلى و قلى). **This is What I've done**
    - The way they are interpreted (الوصل أولى و الوقف أولى)

**Status (please check what you already did)**:
I didn't have to do the first two since tests already exist to 
- [x] updated the documentation
- [x] added some tests for the functionality
- [x] `tox` passes
