### PR TITLE
Fix incorrect time parsing with :data:`~.LAST_SPECIFIC_DAY_OF_SPECIFIC_MONTH`

### DIFF
--- a/maha/parsers/rules/time/values.py
+++ b/maha/parsers/rules/time/values.py
@@ -729,13 +729,9 @@ _start_of_last_day = (
 LAST_SPECIFIC_DAY_OF_SPECIFIC_MONTH = FunctionValue(
     lambda match: parse_value(
         {
-            "month": _months.get_matched_expression(match.group("month")).value.month  # type: ignore
-            + 1
-            if _months.get_matched_expression(match.group("month")).value.month  # type: ignore
-            + 1
-            <= 12
-            else 1,
+            "month": _months.get_matched_expression(match.group("month")).value.month,  # type: ignore
             "weekday": _days.get_matched_expression(match.group("day")).value(-1),  # type: ignore
+            "day": 31,
         }
     ),
     spaced_patterns(_start_of_last_day, named_group("month", _months.join())),

--- a/tests/parsers/test_time.py
+++ b/tests/parsers/test_time.py
@@ -727,6 +727,20 @@ def test_time(expected, input):
 
 
 @pytest.mark.parametrize(
+    "expected,input",
+    [
+        (NOW.replace(day=30), "آخر خميس من شهر 9"),
+        (NOW.replace(day=29), "آخر اربعاء من شهر 9"),
+        (NOW.replace(day=22, month=2), "آخر اثنين من شهر شباط"),
+        (NOW.replace(day=28, month=2), "آخر احد من شهر شباط"),
+    ],
+)
+def test_last_specific_day_of_specific_month(expected, input):
+    output = parse_dimension(input, time=True)
+    assert_expression_output(output, expected)
+
+
+@pytest.mark.parametrize(
     "input",
     [
         ("11"),


### PR DESCRIPTION
**What does this pull request change**?

Fixes #26.

**Status (please check what you already did)**:

- [x] added some tests for the functionality
- [x] updated the documentation
- [x] `tox` passes
