### PR TITLE
Time: Made next/previous specific month time parsing independent of current time

### DIFF
--- a/maha/parsers/rules/time/template.py
+++ b/maha/parsers/rules/time/template.py
@@ -1,5 +1,7 @@
 __all__ = ["TimeValue"]
 
+from datetime import datetime
+
 from dateutil.relativedelta import relativedelta
 
 
@@ -28,6 +30,8 @@ class TimeValue(relativedelta):
         second=None,
         microsecond=None,
         am_pm=None,
+        next_month=None,
+        prev_month=None,
     ):
         self._years = years
         self._months = months
@@ -39,6 +43,8 @@ class TimeValue(relativedelta):
         self._seconds = seconds
         self._microseconds = microseconds
         self._am_pm = am_pm
+        self.next_month = next_month
+        self.prev_month = prev_month
 
         # handle hour am pm
         if am_pm == "PM" and hour is not None and hour < 12:
@@ -128,7 +134,27 @@ class TimeValue(relativedelta):
                     else self.microsecond
                 ),
                 am_pm=other._am_pm or self._am_pm,
+                next_month=(
+                    other.next_month
+                    if other.next_month is not None
+                    else self.next_month
+                ),
+                prev_month=(
+                    other.prev_month
+                    if other.prev_month is not None
+                    else self.prev_month
+                ),
             )
+        # Handle next/prev month
+        if isinstance(other, datetime):
+            current_month = other.month
+            if self.next_month:
+                self.years += 1 if self.next_month <= current_month else 0
+                self.month = self.next_month
+            elif self.prev_month:
+                self.years += 0 if self.prev_month <= current_month else -1
+                self.month = self.prev_month
+
         return super().__add__(other)
 
     def __repr__(self):

--- a/maha/parsers/rules/time/values.py
+++ b/maha/parsers/rules/time/values.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from dateutil.relativedelta import FR, MO, SA, SU, TH, TU, WE
 
 import maha.parsers.rules.numeral.values as numvalues
@@ -413,45 +411,44 @@ BEFORE_N_MONTHS = FunctionValue(
 )
 
 
-def specific_month(match, next_month=False, years=0):
-    month = _months.get_matched_expression(match.group("value")).value.month  # type: ignore
-    current_month = datetime.now().month
-    if next_month:
-        years += 1 if month <= current_month else 0
-    else:
-        years += 0 if month <= current_month else -1
-    return parse_value(
-        {
-            "month": month,
-            "years": years,
-        }
-    )
-
-
 SPECIFIC_MONTH = MatchedValue(_months, _months.join())
 NEXT_SPECIFIC_MONTH = FunctionValue(
-    lambda match: specific_month(match, next_month=True),
+    lambda match: parse_value(
+        {"next_month": _months.get_matched_expression(match.group("value")).value.month}  # type: ignore
+    ),
     non_capturing_group(
         spaced_patterns(ONE_MONTH, value_group(_months.join()), NEXT),
         spaced_patterns(value_group(_months.join()), NEXT),
     ),
 )
 PREVIOUS_SPECIFIC_MONTH = FunctionValue(
-    lambda match: specific_month(match, next_month=False),
+    lambda match: parse_value(
+        {"prev_month": _months.get_matched_expression(match.group("value")).value.month}  # type: ignore
+    ),
     non_capturing_group(
         spaced_patterns(ONE_MONTH, value_group(_months.join()), PREVIOUS),
         spaced_patterns(value_group(_months.join()), PREVIOUS),
     ),
 )
 AFTER_SPECIFIC_NEXT_MONTH = FunctionValue(
-    lambda match: specific_month(match, next_month=True, years=1),
+    lambda match: parse_value(
+        {
+            "next_month": _months.get_matched_expression(match.group("value")).value.month,  # type: ignore
+            "years": 1,
+        }
+    ),
     non_capturing_group(
         spaced_patterns(ONE_MONTH, value_group(_months.join()), AFTER_NEXT),
         spaced_patterns(value_group(_months.join()), AFTER_NEXT),
     ),
 )
 BEFORE_SPECIFIC_PREVIOUS_MONTH = FunctionValue(
-    lambda match: specific_month(match, years=-1),
+    lambda match: parse_value(
+        {
+            "prev_month": _months.get_matched_expression(match.group("value")).value.month,  # type: ignore
+            "years": -1,
+        }
+    ),
     non_capturing_group(
         spaced_patterns(ONE_MONTH, value_group(_months.join()), BEFORE_PREVIOUS),
         spaced_patterns(value_group(_months.join()), BEFORE_PREVIOUS),

--- a/tests/parsers/test_time.py
+++ b/tests/parsers/test_time.py
@@ -229,7 +229,6 @@ def test_specific_month(expected_month, input):
 def test_next_specific_month_same_year(expected_month, input):
     output = list(RULE_TIME_MONTHS(input))
     assert_expression_date_output(output, datetime(2021, expected_month, 1))
-    assert output[0].value == TimeValue(years=0, month=expected_month)
 
 
 @pytest.mark.parametrize(
@@ -246,7 +245,6 @@ def test_next_specific_month_same_year(expected_month, input):
 def test_next_specific_month_next_year(expected_month, input):
     output = list(RULE_TIME_MONTHS(input))
     assert_expression_date_output(output, datetime(2022, expected_month, 1))
-    assert output[0].value == TimeValue(years=1, month=expected_month)
 
 
 @pytest.mark.parametrize(
@@ -266,7 +264,6 @@ def test_next_specific_month_next_year(expected_month, input):
 def test_previous_specific_month_previous_year(expected_month, input):
     output = list(RULE_TIME_MONTHS(input))
     assert_expression_date_output(output, datetime(2020, expected_month, 1))
-    assert output[0].value == TimeValue(years=-1, month=expected_month)
 
 
 @pytest.mark.parametrize(
@@ -279,7 +276,6 @@ def test_previous_specific_month_previous_year(expected_month, input):
 def test_previous_specific_month_same_year(expected_month, input):
     output = list(RULE_TIME_MONTHS(input))
     assert_expression_date_output(output, datetime(2021, expected_month, 1))
-    assert output[0].value == TimeValue(years=0, month=expected_month)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What does this pull request change**?

Fixes failing tests caused by this line that depends on the current month while parsing https://github.com/TRoboto/Maha/blob/036fa28b9c110332657fe565daa9afe687fb62f8/maha/parsers/rules/time/values.py#L418

**Status (please check what you already did)**:

- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] `tox` passes
