### PR TITLE
Simplify :class:`~.TimeInterval` to include `start`/`end` instead of `from_time`/`to_time`

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -310,20 +310,20 @@ Examples
     >>> from datetime import datetime
     >>> now = datetime(2021, 9, 15)
     >>> parse_dimension("من الساعة 9 الى 11 صباحا", time=True)
-    [Dimension(body=من الساعة 9 الى 11 صباحا, value=TimeInterval(from_time=TimeValue(am_pm='AM', hour=9, minute=0, second=0, microsecond=0), to_time=TimeValue(am_pm='AM', hour=11, minute=0, second=0, microsecond=0)), start=0, end=24, dimension_type=DimensionType.TIME)]
+    [Dimension(body=من الساعة 9 الى 11 صباحا, value=TimeInterval(start=TimeValue(am_pm='AM', hour=9, minute=0, second=0, microsecond=0), end=TimeValue(am_pm='AM', hour=11, minute=0, second=0, microsecond=0)), start=0, end=24, dimension_type=DimensionType.TIME)]
     >>> interval = parse_dimension("من 13 هذا الشهر الى 20 الشهر القادم", time=True)[0].value
     >>> interval
-    TimeInterval(from_time=TimeValue(months=0, day=13), to_time=TimeValue(months=1, day=20))
-    >>> interval.from_time + now
+    TimeInterval(start=TimeValue(months=0, day=13), end=TimeValue(months=1, day=20))
+    >>> interval.start + now
     datetime.datetime(2021, 9, 13, 0, 0)
-    >>> interval.to_time + now
+    >>> interval.end + now
     datetime.datetime(2021, 10, 20, 0, 0)
     >>> parse_dimension("الساعة ثلاثة الا ثلث للساعة 4 ونص", time=True)[0].value
-    TimeInterval(from_time=TimeValue(hour=2, minute=40, second=0, microsecond=0), to_time=TimeValue(hour=4, minute=30, second=0, microsecond=0))
+    TimeInterval(start=TimeValue(hour=2, minute=40, second=0, microsecond=0), end=TimeValue(hour=4, minute=30, second=0, microsecond=0))
     >>> parse_dimension("من 6 اكتوبر", time=True)[0].value
-    TimeInterval(from_time=TimeValue(month=10, day=6), to_time=None)
+    TimeInterval(start=TimeValue(month=10, day=6), end=None)
     >>> parse_dimension("حتى الرابعة وربع بعد العصر", time=True)[0].value
-    TimeInterval(from_time=None, to_time=TimeValue(am_pm='PM', hour=16, minute=15, second=0, microsecond=0))
+    TimeInterval(start=None, end=TimeValue(am_pm='PM', hour=16, minute=15, second=0, microsecond=0))
 
 
 * To extract names, you can do the following:

--- a/maha/parsers/rules/time/rule.py
+++ b/maha/parsers/rules/time/rule.py
@@ -106,13 +106,13 @@ def parse_time(match):
 
     # to time only
     if contains_to_time() and TO.match(text):
-        return TimeInterval(to_time=value)
+        return TimeInterval(end=value)
 
     # from time only
     elif FROM.match(text) and (
         not contains_to_time() or contains_to_time() and not groups["to_time"]
     ):
-        return TimeInterval(from_time=value)
+        return TimeInterval(start=value)
 
     # time only
     return value

--- a/maha/parsers/rules/time/template.py
+++ b/maha/parsers/rules/time/template.py
@@ -232,5 +232,5 @@ class TimeValue(relativedelta):
 
 @dataclass
 class TimeInterval:
-    from_time: Optional[TimeValue] = None
-    to_time: Optional[TimeValue] = None
+    start: Optional[TimeValue] = None
+    end: Optional[TimeValue] = None

--- a/tests/parsers/test_time.py
+++ b/tests/parsers/test_time.py
@@ -778,15 +778,15 @@ def assert_interval_output(output, start_time, end_time):
     assert isinstance(value, TimeInterval)
 
     if start_time is not None:
-        assert isinstance(value.from_time, TimeValue)
-        assert NOW + value.from_time == start_time
+        assert isinstance(value.start, TimeValue)
+        assert NOW + value.start == start_time
     else:
-        assert value.from_time is None
+        assert value.start is None
     if end_time is not None:
-        assert isinstance(value.to_time, TimeValue)
-        assert NOW + value.to_time == end_time
+        assert isinstance(value.end, TimeValue)
+        assert NOW + value.end == end_time
     else:
-        assert value.to_time is None
+        assert value.end is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What does this pull request change**?

- Changes `from_time`/`to_time` to `start`/`end`.

**Status (please check what you already did)**:

- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] `tox` passes
