### PR TITLE
Fix tests not passing when order changes due to monkeypatching

### DIFF
--- a/tests/parsers/test_time.py
+++ b/tests/parsers/test_time.py
@@ -27,10 +27,6 @@ def assert_expression_date_output(output, expected):
     assert DATE + output.value == expected
 
 
-def set_start_of_week(day):
-    pytest.MonkeyPatch().setattr(constants, "START_OF_WEEK", day.weekday)
-
-
 @pytest.mark.parametrize(
     "input",
     [
@@ -785,8 +781,8 @@ def test_last_specific_day_of_specific_month(expected, input):
         (TU, NOW.replace(month=8, day=30), "الأسبوع الماضي يوم الاثنين"),
     ],
 )
-def test_different_start_of_week(sow, expected, input):
-    set_start_of_week(sow)
+def test_different_start_of_week(sow, expected, input, monkeypatch):
+    monkeypatch.setattr(constants, "START_OF_WEEK", sow.weekday)
     output = parse_dimension(input, time=True)
     assert_expression_output(output, expected)
 


### PR DESCRIPTION
**What does this pull request change**?
 
Made mokeypatch reset to the default behavior after each test.

**Status (please check what you already did)**:

- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] `tox` passes
