### PR TITLE
Reordered the changelogs so that the most recent appears first

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 .. toctree::
     :maxdepth: 1
 
-    changelog/0.1.1-changelog
-    changelog/0.2.0-changelog
-    changelog/0.3.0-changelog
     .. next-changelog
+    changelog/0.3.0-changelog
+    changelog/0.2.0-changelog
+    changelog/0.1.1-changelog

--- a/tools/gen_changelog.py
+++ b/tools/gen_changelog.py
@@ -78,7 +78,7 @@ def update_citation(version, date):
 def update_changelog_tree(path: Path):
     with open(path.parents[1] / "changelog.rst") as f:
         newtext = f.read().replace(
-            ".. next-changelog", f"changelog/{path.stem}\n{' '*4}.. next-changelog"
+            ".. next-changelog", f".. next-changelog\n{' '*4}changelog/{path.stem}"
         )
     with open(path.parents[1] / "changelog.rst", "w") as f:
         f.write(newtext)


### PR DESCRIPTION
**What does this pull request change**?

- Previously new changelogs were added at the bottom. With this change, new changelogs are added to the top. 
- Old changelogs are reordered as well.

**Status (please check what you already did)**:

- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] `tox` passes
